### PR TITLE
#91 add parameters plugin

### DIFF
--- a/src/tb/apps/content/components/ContentManager.js
+++ b/src/tb/apps/content/components/ContentManager.js
@@ -23,7 +23,7 @@ define(
         'content.models.Content',
         'content.models.ContentSet',
         'definition.manager',
-        'content.container.manager',
+        'content.container',
         'content.repository',
         'jsclass'
     ],

--- a/src/tb/apps/content/components/DndManager.js
+++ b/src/tb/apps/content/components/DndManager.js
@@ -24,7 +24,7 @@ define(
         'jquery',
         'text!content/tpl/dropzone',
         'component!dnd',
-        'content.container.manager',
+        'content.container',
         'content.manager',
         'jsclass'
     ],

--- a/src/tb/apps/content/components/MouseEventManager.js
+++ b/src/tb/apps/content/components/MouseEventManager.js
@@ -21,7 +21,7 @@ define(
     [
         'tb.core',
         'jquery',
-        'content.container.manager',
+        'content.container',
         'content.manager',
         'jsclass'
     ],

--- a/src/tb/apps/content/main.js
+++ b/src/tb/apps/content/main.js
@@ -34,7 +34,7 @@ require.config({
         'content.dnd.manager': 'src/tb/apps/content/components/DndManager',
         'content.mouseevent.manager': 'src/tb/apps/content/components/MouseEventManager',
         'content.save.manager': 'src/tb/apps/content/components/SaveManager',
-        'content.container.manager': 'src/tb/apps/content/components/ContentContainer',
+        'content.container': 'src/tb/apps/content/components/ContentContainer',
         'definition.manager': 'src/tb/apps/content/components/DefinitionManager',
         'content.breadcrumb': 'src/tb/apps/content/components/Breadcrumb',
         'content.pluginmanager': 'src/tb/apps/content/components/PluginManager',

--- a/src/tb/apps/content/models/AbstractContent.js
+++ b/src/tb/apps/content/models/AbstractContent.js
@@ -60,14 +60,14 @@ define(
             setUpdated: function (isUpdate) {
                 if (typeof isUpdate === 'boolean') {
                     this.updated = isUpdate;
-
-                    this.retrieveData();
                 }
             },
 
             set: function (key, value) {
                 if (key === 'value') {
                     this.revision.addElement(key, value);
+
+                    this.setUpdated(true);
                 } else {
                     this[key] = value;
                 }
@@ -137,6 +137,12 @@ define(
                 return result;
             },
 
+            setParameters: function (parameters) {
+                this.revision.setParameters(parameters);
+
+                this.setUpdated(true);
+            },
+
             /**
              * Retrieve the data and set the data
              */
@@ -153,7 +159,8 @@ define(
              * @returns {Promise}
              */
             getData: function (key, async) {
-                var dfd = jQuery.Deferred(),
+                var self = this,
+                    dfd = jQuery.Deferred(),
                     func = function (data, key) {
                         var result = null;
 
@@ -168,13 +175,14 @@ define(
 
                 if (this.data === undefined) {
                     ContentRepository.findData(this.type, this.uid).done(function (data) {
+                        self.data = data;
                         dfd.resolve(func(data, key));
                     });
                 } else {
-                    if (!async) {
+                    if (async === false) {
                         return func(this.data, key);
                     }
-                    dfd.promise(func(this.data, key));
+                    dfd.resolve(func(this.data, key));
                 }
 
                 return dfd.promise();

--- a/src/tb/apps/content/models/ContentRevision.js
+++ b/src/tb/apps/content/models/ContentRevision.js
@@ -56,7 +56,13 @@ define(['jsclass'], function () {
         },
 
         setParameters: function (parameters) {
-            this.parameters = parameters;
+            if (parameters !== undefined && Object.keys(parameters).length > 0) {
+                this.parameters = parameters;
+            } else {
+                if (this.hasOwnProperty('parameters')) {
+                    delete this.parameters;
+                }
+            }
         },
 
         addParam: function (key, param) {

--- a/src/tb/apps/content/plugins/parameters/main.js
+++ b/src/tb/apps/content/plugins/parameters/main.js
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2011-2013 Lp digital system
+ *
+ * This file is part of BackBuilder5.
+ *
+ * BackBuilder5 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBuilder5 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBuilder5. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+define(
+    [
+        'content.pluginmanager',
+        'component!popin',
+        'component!formbuilder',
+        'jsclass'
+    ],
+    function (PluginManager, Popin, FormBuilder) {
+
+        'use strict';
+
+        PluginManager.registerPlugin('parameters', {
+
+            /**
+             * Initialization of plugin
+             */
+            onInit: function () {
+                this.createPopin();
+                this.content = this.getCurrentContent();
+            },
+
+            /**
+             * Create popin for parameters form
+             */
+            createPopin: function () {
+                this.popin = Popin.createPopIn();
+                this.popin.setTitle('Parameters');
+            },
+
+            /**
+             * Build form from parameters and show popin
+             */
+            showParameters: function () {
+                var self = this;
+
+                this.content.getData().done(function () {
+                    var parameters = self.content.getParameters(),
+                        config = {
+                            elements: parameters,
+                            onSubmit: function (data) {
+                                if (Object.keys(data).length > 0) {
+                                    self.content.setParameters(data);
+                                }
+                                self.popin.hide();
+                            }
+                        };
+
+                    FormBuilder.renderForm(config).done(function (html) {
+                        self.popin.setContent(html);
+                        self.popin.display();
+                    });
+                });
+            },
+
+            /**
+             * Verify if the plugin can be apply on the context
+             * @returns {Boolean}
+             */
+            canApplyOnContext: function () {
+                return true;
+            },
+
+            /**
+             * 
+             * @returns {Array}
+             */
+            getActions: function () {
+                var self = this;
+
+                return [
+                    {
+                        name: 'parameters',
+                        ico: 'fa fa-circle-o',
+                        label: 'Parameters',
+                        cmd: self.createCommand(self.showParameters, self),
+                        checkContext: function () {
+                            return true;
+                        }
+                    }
+                ];
+            }
+        });
+    }
+);

--- a/src/tb/config.js
+++ b/src/tb/config.js
@@ -75,6 +75,10 @@ define([], function () {
                 contenttype: {
                     accept: ['home/home_container', 'block_demo'],
                     config: {}
+                },
+                parameters: {
+                    accept: ['home/home_container', 'block_demo'],
+                    config: {}
                 }
             },
             "demo": { }


### PR DESCRIPTION
On select a content a button "parameters" must be appear.
On click on this button a form must be build with a content definition provided by API.
Manage save with parameters.

For example:
![parameters-plugin](https://cloud.githubusercontent.com/assets/9247945/5627432/1bd9a8e4-9598-11e4-97fd-548caff7061e.png)
