### PR TITLE
Add requirement system to load dependency upon request #136

### DIFF
--- a/src/tb/core/ApplicationManager.js
+++ b/src/tb/core/ApplicationManager.js
@@ -90,10 +90,21 @@ define('tb.core.ApplicationManager', ['require', 'BackBone', 'jsclass', 'jquery'
             invokeControllerService: function (controller, service, params) {
                 var dfd = new $.Deferred(),
                     serviceName;
+
                 ControllerManager.loadControllerByShortName(this.getName(), controller).done(function (controller) {
                     try {
                         serviceName = service + "Service";
-                        dfd.resolve(controller[serviceName].apply(controller, params));
+                        controller.beforeCall(serviceName).then(
+                            function (req) {
+                                if (req) {
+                                    params.unshift(req);
+                                }
+                                dfd.resolve(controller[serviceName].apply(controller, params));
+                            },
+                            function () {
+                                dfd.resolve(controller[serviceName].apply(controller, params));
+                            }
+                        );
                     } catch (reason) {
                         dfd.reject(reason);
                     }

--- a/src/tb/core/ControllerManager.js
+++ b/src/tb/core/ControllerManager.js
@@ -63,6 +63,27 @@ define('tb.core.ControllerManager', ['require', 'tb.core.Api', 'tb.core.Applicat
                 }
                 return def.promise();
             },
+
+            beforeCall: function (callName) {
+                var dfd = new jQuery.Deferred(),
+                    self = this;
+
+                if (this.config.define !== undefined &&  this.config.define[callName] !== undefined) {
+                    utils.requireWithPromise(this.config.define[callName]).then(
+                        function () {
+                            dfd.resolve.call(self, require);
+                        },
+                        function () {
+                            dfd.reject.call(self);
+                        }
+                    );
+                } else {
+                    dfd.resolve.call(self, false);
+                }
+
+                return dfd.promise();
+            },
+
             /**
              * Action automaticly call when the Controller is Enabled
              * @return {false}
@@ -235,21 +256,27 @@ define('tb.core.ControllerManager', ['require', 'tb.core.Api', 'tb.core.Applicat
                 completeControllerName,
                 controllerInfos,
                 ctlFileName = appName + '.' + shortControllerName + '.controller';
+
             if (!appName || typeof appName !== 'string') {
                 exception(15005, 'appName have to be defined as String');
             }
+
             if (!appName || typeof appName !== 'string') {
                 exception(15006, 'shortControllerName have to be defined as String');
             }
+
             controllerInfos = shortNameMap[appName + ':' + shortControllerName];
+
             if (controllerInfos) {
                 return loadController(appName, controllerInfos.originalName);
             }
+
             /*first, because of the use shortName, we need load the controller*/
             utils.requireWithPromise([ctlFileName]).done(function () {
                 completeControllerName = shortNameMap[appName + ':' + shortControllerName].originalName;
                 return loadController(appName, completeControllerName).done(dfd.resolve).fail(dfd.reject);
             }).fail(dfd.reject);
+
             return dfd.promise();
         },
         /**


### PR DESCRIPTION
I have apply that only on controller service because they are already async by creating a function beforeCall.

If the system is used, your service will get a require instance in first parameter.

to use the system you to add this config inner the controller :
```javascript
config: {
    define: {
        oneService: ['one/repository', 'dependency/you/need']
    }
}
```