### PR TITLE
[RestDriver] request url construction with identifier has integer don't work #160

### DIFF
--- a/src/tb/core/RestDriver.js
+++ b/src/tb/core/RestDriver.js
@@ -123,7 +123,7 @@ define('tb.core.RestDriver', ['tb.core.Request', 'tb.core.RequestHandler', 'URIj
                 for (criteria in criterias) {
                     if (criterias.hasOwnProperty(criteria)) {
                         if ('uid' === criteria || 'id' === criteria) {
-                            url.segment(criterias[criteria]);
+                            url.segment(criterias[criteria].toString());
                         } else {
                             url.addSearch(criteria + (typeof criterias[criteria] === 'object' ? '[]' : ''), criterias[criteria]);
                         }


### PR DESCRIPTION
Add toString() method on the criteria to be sure the url segment get an String has parameter.