### PR TITLE
Create visual zone to show number of core.exception #182

### DIFF
--- a/src/tb/component/exceptions-viewer/main.js
+++ b/src/tb/component/exceptions-viewer/main.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2011-2013 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ */
+define('tb.component/exceptions-viewer/main', function () {
+    'use strict';
+
+    return {
+        init: function (config) {
+            if (config.show === true) {
+                require(['tb.component/exceptions-viewer/viewer'], function (exceptions) {
+                    exceptions();
+                });
+            }
+        }
+    };
+});

--- a/src/tb/component/exceptions-viewer/viewer.js
+++ b/src/tb/component/exceptions-viewer/viewer.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2011-2013 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ */
+define('tb.component/exceptions-viewer/viewer', ['tb.core'], function (Core) {
+    'use strict';
+
+    var template = '<div id="toolbar-count-errors" class="errors">0</div>',
+
+        showExceptions = function () {
+            Core.get('errors').forEach(function (error) {
+                console.warn(error);
+            });
+        };
+
+    return function () {
+        document.getElementsByTagName('body')[0].insertAdjacentHTML('beforeend', template);
+        var element = document.getElementById('toolbar-count-errors');
+        element.style.position = 'fixed';
+        element.style.top = '4px';
+        element.style.left = '5px';
+        element.style.backgroundColor = 'red';
+        element.style.color = 'white';
+        element.style.display = 'none';
+        element.style.zIndex = 99999999;
+        element.style.cursor = 'pointer';
+        element.style.padding = '2px 3px';
+        element.style.fontWeight = 'bold';
+
+        element.addEventListener('click', showExceptions);
+
+        Core.Mediator.subscribe('api:set:lastError', function () {
+            element.innerHTML = parseInt(element.innerHTML, 10) + 1;
+            element.style.display = 'block';
+        });
+    };
+});

--- a/src/tb/config.js
+++ b/src/tb/config.js
@@ -51,6 +51,9 @@ define([], function () {
             logger: {
                 level: 8,
                 mode: 'devel'
+            },
+            'exceptions-viewer': {
+                show: true
             }
         },
 

--- a/src/tb/core/Api.js
+++ b/src/tb/core/Api.js
@@ -33,6 +33,7 @@ define('tb.core.Api', [], function () {
             },
 
             set: function (ctn, object) {
+                this.Mediator.publish('api:set:' + ctn, object);
                 container[ctn] = object;
             },
 

--- a/src/tb/init.js
+++ b/src/tb/init.js
@@ -58,6 +58,7 @@ define(['jquery'], function (jQuery) {
 
                     if (true === already_connected) {
                         Core.initConfig(config);
+                        require(['component!exceptions-viewer'], {});
                     } else {
                         Core.Mediator.subscribe('onSuccessLogin', function () {
                             self.toolBarDisplayed = true;


### PR DESCRIPTION
A little component to show the number of exception raised with Core.exception.

This coponent subscribe on the event 'api:set:lastError' and automaticly include a div into the document with the number of errors and on click on this div, we have console warn off each exceptions raised in the application.
For that, I add a mediator publish call into the api set function.
I know the fact of is disgusting to add style with the javascript, but we need to find a better way to include component css with out including it into bb-ui.less. 

And there is a little typo correction in component.js.