### PR TITLE
#198 [Content] [Plugins] [ContentSelector] Bad context for creation of the command

### DIFF
--- a/src/tb/apps/content/plugins/contentselector/main.js
+++ b/src/tb/apps/content/plugins/contentselector/main.js
@@ -34,6 +34,7 @@ define(['content.pluginmanager', 'tb.core.Api', 'component!contentselector', 'jq
             /* set Accept and other things */
             var currentContent = this.getCurrentContent(),
                 accept = currentContent.definition.accept;
+
             this.contentSelector.setContenttypes(accept);
             this.contentSelector.display();
         },
@@ -46,7 +47,7 @@ define(['content.pluginmanager', 'tb.core.Api', 'component!contentselector', 'jq
             var self = this;
             return [{
                 ico: 'fa fa-th-large',
-                cmd: this.createCommand(this.showContentSelector, self),
+                cmd: self.createCommand(self.showContentSelector, self),
                 label: 'Contents selector',
                 checkContext: function () {
                     return self.canApplyOnContext();


### PR DESCRIPTION
On get action, the creation command is in an object.
The createCommand function is used by this instead of self.