### PR TITLE
[RFR] Translator core library

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,6 +33,7 @@
     "ckeeditor": "git://github.com/ckeditor/ckeditor-releases.git#standard/stable"
   },
   "devDependencies": {
-    "uri.js": "~1.14.1"
+    "uri.js": "~1.14.1",
+    "es5-shim": "~4.1.0"
   }
 }

--- a/specs/require.config.js
+++ b/specs/require.config.js
@@ -4,6 +4,7 @@ require.config({
     paths: {
         'tb.core': 'src/tb/main',
         'component': 'src/tb/component/component',
+
         'jquery': 'bower_components/jquery/dist/jquery.min',
         'jqueryui': 'bower_components/jquery-ui/jquery-ui.min',
         'jsclass' : 'node_modules/jsclass/min/core',
@@ -18,8 +19,11 @@ require.config({
         'lib.jqtree': 'bower_components/jqtree/tree.jquery',
         'jssimplepagination': 'bower_components/jssimplepagination/jquery.simplePagination',
         'ckeeditor' : 'lib/ckeeditor/ckeditor',
+
         'jasmine': 'node_modules/grunt-contrib-jasmine/vendor/jasmine-2.0.0/jasmine',
         'jasmine-html': 'node_modules/grunt-contrib-jasmine/vendor/jasmine-2.0.0/jasmine-html',
+        'es5-shim': 'bower_components/es5-shim',
+
         'spec': 'specs/'
     },
     shim: {

--- a/specs/tb/component/translator/Translator.spec.js
+++ b/specs/tb/component/translator/Translator.spec.js
@@ -1,39 +1,50 @@
-define(['component!translator', 'component!logger'], function (Translator, Logger) {
+define(['component!translator', 'component!logger', 'tb.core.Renderer', 'es5-shim/es5-shim'], function (Translator, Logger, Renderer) {
     'use strict';
 
     Translator.init({'locale': 'en_US', 'base': 'src/tb/i18n/'});
     var locale_fr = "fr_FR";
 
     describe("Translator core library test suite", function () {
+
         it("Should translate the key from default catalog", function () {
             expect(Translator.translate('app_validate')).toEqual('Validate');
         });
+
         it("Should set a new locale", function () {
             Translator.setLocale(locale_fr);
             expect(Translator.getLocale()).toEqual(locale_fr);
         });
+
         it("Should translate the key with another locale than default's one", function () {
             Translator.setLocale(locale_fr);
             expect(Translator.translate('app_validate')).toEqual('Valider');
         });
+
         it("Should return the default locale value if requested is not available", function () {
             Translator.setLocale(locale_fr);
             expect(Translator.translate('app_only_default')).toEqual('Only default');
         });
+
         it("Should log a notice if the translation for the selected catalog is not found", function () {
             spyOn(Logger, "notice").and.returnValue('The key "foo.bar" is malformed.').and.callThrough();
             Translator.setLocale(locale_fr);
             Translator.translate('app_only_default');
             expect(Logger.notice).toHaveBeenCalled();
         });
+
         it("Should return at least the key if key is malformed", function () {
             Translator.setLocale(locale_fr);
             expect(Translator.translate('app_only_not_default')).toEqual('app_only_not_default');
         });
+
         it("Should log a warning if the translation is not found", function () {
             spyOn(Logger, "warning").and.returnValue('The key "foo.bar" is malformed.').and.callThrough();
             Translator.translate('foo.bar');
             expect(Logger.warning).toHaveBeenCalled();
+        });
+
+        it("Should be able to render key in Renderer scope", function () {
+            expect(Renderer.render("{{ 'app_validate' | trans }}")).toEqual('Valider');
         });
     });
 });

--- a/specs/tb/component/translator/Translator.spec.js
+++ b/specs/tb/component/translator/Translator.spec.js
@@ -1,0 +1,39 @@
+define(['component!translator', 'component!logger'], function (Translator, Logger) {
+    'use strict';
+
+    Translator.init({'locale': 'en_US', 'base': 'src/tb/i18n/'});
+    var locale_fr = "fr_FR";
+
+    describe("Translator core library test suite", function () {
+        it("Should translate the key from default catalog", function () {
+            expect(Translator.translate('app_validate')).toEqual('Validate');
+        });
+        it("Should set a new locale", function () {
+            Translator.setLocale(locale_fr);
+            expect(Translator.getLocale()).toEqual(locale_fr);
+        });
+        it("Should translate the key with another locale than default's one", function () {
+            Translator.setLocale(locale_fr);
+            expect(Translator.translate('app_validate')).toEqual('Valider');
+        });
+        it("Should return the default locale value if requested is not available", function () {
+            Translator.setLocale(locale_fr);
+            expect(Translator.translate('app_only_default')).toEqual('Only default');
+        });
+        it("Should log a notice if the translation for the selected catalog is not found", function () {
+            spyOn(Logger, "notice").and.returnValue('The key "foo.bar" is malformed.').and.callThrough();
+            Translator.setLocale(locale_fr);
+            Translator.translate('app_only_default');
+            expect(Logger.notice).toHaveBeenCalled();
+        });
+        it("Should return at least the key if key is malformed", function () {
+            Translator.setLocale(locale_fr);
+            expect(Translator.translate('app_only_not_default')).toEqual('app_only_not_default');
+        });
+        it("Should log a warning if the translation is not found", function () {
+            spyOn(Logger, "warning").and.returnValue('The key "foo.bar" is malformed.').and.callThrough();
+            Translator.translate('foo.bar');
+            expect(Logger.warning).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/tb/component/translator/main.js
+++ b/src/tb/component/translator/main.js
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2011-2013 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ */
+define('tb.component/translator/main', ['component!logger', 'jquery'], function (Logger, jQuery) {
+    'use strict';
+
+        /*
+         * BackBee Translator component
+         * Allow to set multiples dictionnary files
+         *
+         * Can be accessed throught templates using global function 'trans'
+         * Ex: <h1>{{ trans('hello_world') }}</h1> will return "Hello world"
+         *
+         * // /i18n/en_US/global.js
+         * {
+         *      'hello_world' : 'Hello world'
+         * }
+         */
+    var Translator = {
+            init: function (config) {
+                this.base = config.base;
+                this.catalog = {};
+                this.config = config;
+                this.locale = config.locale;
+                this.loadCatalog();
+            },
+
+            getLocale:  function () {
+                return this.locale;
+            },
+
+            setLocale: function (locale) {
+                this.loadCatalog();
+                this.locale = locale;
+            },
+
+            getDefaultLocale: function () {
+                return this.config.locale;
+            },
+
+            translate: function (key) {
+                var translation = key;
+                if (this.catalog[key] !== undefined) {
+                    translation = this.catalog[key];
+                } else if (this.getDefaultCatalog()[key] !== undefined) {
+                    Logger.notice('The key "' + key + '" has not translation in the selected catalog.');
+                    translation = this.getDefaultCatalog()[key];
+                } else {
+                    Logger.warning('The key "' + key + '" is malformed.');
+                }
+
+                return translation;
+            },
+
+            getCatalog: function () {
+                return this.catalog;
+            },
+
+            getDefaultCatalog: function () {
+                this.loadCatalog(this.getDefaultLocale());
+
+                return this.catalog;
+            },
+
+            loadCatalog: function (locale) {
+                var self = this,
+                    myLocale = (locale === undefined) ? self.locale : locale;
+                jQuery.ajax({
+                    'url': self.base + '/' + myLocale + '/global.json',
+                    'data': 'json',
+                    'async': false
+                })
+                    .done(function (response) {
+                        self.catalog = JSON.parse(response, true);
+                    });
+            }
+        };
+
+    return Translator;
+});

--- a/src/tb/config.js
+++ b/src/tb/config.js
@@ -75,6 +75,10 @@ define([], function () {
             },
             'exceptions-viewer': {
                 show: true
+            },
+            translator: {
+                base: 'src/tb/i18n/',
+                locale: 'en_US'
             }
 
         },

--- a/src/tb/core/Renderer.js
+++ b/src/tb/core/Renderer.js
@@ -29,15 +29,21 @@ define('tb.core.Renderer', ['require', 'nunjucks', 'tb.core', 'jquery', 'tb.core
             initialize: function () {
                 var error_tpl = config.error_tpl || '<p>Error while loading template</p>',
                     placeholder = config.placeholder || '<p>Loading...</p>';
-
+                this.env = nunjucks.configure({ watch: false });
                 this.engine = nunjucks;
                 this.render_action = 'html';
                 this.error_msg = jQuery(error_tpl).clone();
                 this.placeholder = jQuery(placeholder);
+
+                Core.Mediator.persistentPublish('on:renderer:init', this);
             },
 
             getEngine: function () {
                 return this.engine;
+            },
+
+            addFilter: function (name, func, async) {
+                this.env.addFilter(name, func, async);
             },
 
             asyncRender: function (path, params, config) {
@@ -58,7 +64,6 @@ define('tb.core.Renderer', ['require', 'nunjucks', 'tb.core', 'jquery', 'tb.core
 
             render: function (template, params) {
                 params = params || {};
-
                 try {
                     return this.engine.renderString(template, params);
                 } catch (e) {
@@ -86,7 +91,7 @@ define('tb.core.Renderer', ['require', 'nunjucks', 'tb.core', 'jquery', 'tb.core
             config = conf;
         },
 
-        invocMethod = function (method_name) {
+        invokeMethod = function (method_name) {
             return (function (instance) {
                 return function () {
                     var args = Array.prototype.slice.call(arguments);
@@ -97,9 +102,9 @@ define('tb.core.Renderer', ['require', 'nunjucks', 'tb.core', 'jquery', 'tb.core
 
         ApiRender = {
             init: initRenderer,
-            getEngine: invocMethod('getEngine'),
-            render: invocMethod('render'),
-            asyncRender: invocMethod('asyncRender')
+            getEngine: invokeMethod('getEngine'),
+            render: invokeMethod('render'),
+            asyncRender: invokeMethod('asyncRender')
         };
 
     return ApiRender;

--- a/src/tb/i18n/en_US/global.json
+++ b/src/tb/i18n/en_US/global.json
@@ -1,0 +1,4 @@
+{
+    "app_validate": "Validate",
+    "app_only_default": "Only default"
+}

--- a/src/tb/i18n/fr_FR/global.json
+++ b/src/tb/i18n/fr_FR/global.json
@@ -1,0 +1,3 @@
+{
+    "app_validate": "Valider"
+}

--- a/src/tb/init.js
+++ b/src/tb/init.js
@@ -50,7 +50,7 @@ define(['jquery'], function (jQuery) {
             var self = this;
 
             require(['tb.core', 'src/tb/config'], function (Core, config) {
-                require(['tb.core.RestDriver', 'component!authentication'], function (RestDriver, AuthenticationHandler) {
+                require(['tb.core.RestDriver', 'component!authentication', 'component!translator'], function (RestDriver, AuthenticationHandler) {
                     RestDriver.setBaseUrl(jQuery(self.tbSelector).attr('data-api'));
                     Core.set('is_connected', false);
 


### PR DESCRIPTION
Translator component is OK, I will improve it.
After thinking, I think the best place for this module is to be part of core *because* it will be mandatory.

In all cases, component or core, the translator works: I will add more tests and probably try to implement pluralization system.

When I tried to aggregate the translator into Renderer (and finaly, into nunjucks), this won't work.
I investigate a lot (and I will suggest a "Debug" component in the future because Javascript is damn so hard to debug!), and *in fact* the **Renderer don't work as expected**.

- [x] Component translator
    - [x] Should return a value for a key in default catalog
    - [x] Should return a value for a key in another catalog when new locale is set
    - [x] Should be able to return default value if translation is not available in the selected catalog
    - [x] Should log a notice when this is not the translation from the selected catalog  
    - [x] Should return the key is the key is not available at all
    - [x] Should log a warning exception in this case
    - [x] Store all loaded catalogs into un object indexed by locale (*limit ajax calls by @ndufreche* )
- [x] Renderer integration
    - [x] Should register an event on application initialization
    - [x] Should make ``trans()`` fonction from translator available in Renderer in main App scope
    - [x] Should be tested
    - [x] Move logic of filters outside Renderer
- [x] Docs
    - [x] Translator
    - [x] Filters in Renderer

**update 20/02 17h49**: docs are to be done in another repo

**update 20/02 16h51**: the component work the way we expected :)

