### PR TITLE
[RFR] - Added Renderer tests

### DIFF
--- a/specs/tb/core/Renderer.spec.js
+++ b/specs/tb/core/Renderer.spec.js
@@ -1,0 +1,21 @@
+define(['tb.core.Renderer', 'nunjucks', 'es5-shim/es5-shim'], function (Renderer, nunjucks) {
+    'use strict';
+
+    describe("Renderer test suite", function () {
+        it("Should render simple strings", function () {
+            expect(Renderer.render('Hello world')).toEqual('Hello world');
+        });
+
+        it("Should render string with variables", function () {
+            expect(Renderer.render('Hello {{ world }}', {'world': 'world'})).toEqual('Hello world');
+        });
+
+        it("Should ignore undefined variables on render()", function () {
+            expect(Renderer.render('Hello {{ not_defined_var }}', {})).toEqual('Hello ');
+        });
+
+        it("Should return nunjucks instance when getEngine() is called", function () {
+            expect(Renderer.getEngine() === nunjucks).toBe(true);
+        });
+    });
+});

--- a/src/tb/core/Renderer.js
+++ b/src/tb/core/Renderer.js
@@ -46,6 +46,9 @@ define('tb.core.Renderer', ['require', 'nunjucks', 'tb.core', 'jquery', 'tb.core
                 this.env.addFilter(name, func, async);
             },
 
+            /**
+             * @todo: this seems to no work.
+             */
             asyncRender: function (path, params, config) {
                 params = params || {};
                 config = config || {};


### PR DESCRIPTION
This is a split of previous PR (https://github.com/backbee/BbCoreJs/pull/206) demonstrating that adding test to cover Renderer core library actualy *broke* the test suite.

This need more investigation, but as it's not related to the **Translator itself** I've done a new pull request.