### PR TITLE
Added  cli option in order to filter tests to execute

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,6 +19,7 @@
 module.exports = function (grunt) {
     'use strict';
 
+    var path = (grunt.option('path') !== undefined) ? grunt.option('path') : undefined;
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
 
@@ -168,7 +169,7 @@ module.exports = function (grunt) {
             test: {
                 src: ['<%= dir.src %>/core/**/*.js', '<%= dir.src %>/component/**/*.js'],
                 options: {
-                    specs: '<%= dir.specs %>/**/*.spec.js',
+                    specs: path || '<%= dir.specs %>/**/*.spec.js',
                     helpers: '<%= dir.specs %>/**/*.helper.js',
                     template: require('grunt-template-jasmine-requirejs'),
                     templateOptions: {
@@ -181,7 +182,7 @@ module.exports = function (grunt) {
             coverage: {
                 src: '<%= jasmine.test.src %>',
                 options: {
-                    specs: '<%= jasmine.test.options.specs %>',
+                    specs: path || '<%= dir.specs %>/**/*.spec.js',
                     template: require('grunt-template-jasmine-istanbul'),
                     templateOptions: {
                         coverage: 'coverage/json/coverage.json',


### PR DESCRIPTION
Each time we want to execute tests, we have to execute all the test suite.

I suggest an easy way to filter the tests to be executed.

Usage:

```bash
➜  BbCoreJs git:(translator-component) grunt jasmine:coverage --path="component/translator/*.js"
Running "jasmine:coverage" (jasmine) task
Testing jasmine specs via PhantomJS

 Translator core library test suite
   ✓ Should translate the key from default catalog
   ✓ Should set a new locale

=============================== Coverage summary ===============================
Statements   : 10.94% ( 320/2925 )
Branches     : 2.75% ( 33/1198 )
Functions    : 11.37% ( 96/844 )
Lines        : 10.94% ( 320/2925 )
================================================================================

2 specs in 2.394s.
>> 0 failures

Done, without errors.
```

What do you think ?