### PR TITLE
#222 [Content] [PluginManager] + onInit function not called all the time

### DIFF
--- a/src/tb/apps/content/components/PluginManager.js
+++ b/src/tb/apps/content/components/PluginManager.js
@@ -210,11 +210,14 @@ define(['tb.core', 'jquery', 'tb.core.Utils', 'tb.core.Api', 'actionContainer', 
                 try {
                     var pluginName = pluginInfos.name,
                         pluginInstance = new this.pluginsInfos[pluginName]();
+
                     this.pluginsInstance[pluginInfos.completeName] = pluginInstance;
                     pluginInstance.setConfig(pluginInfos.config);
                     pluginInstance.setContext(this.context);
+
+                    pluginInstance.onInit();
+
                     if (this.isScopeValid(pluginInstance) && pluginInstance.canApplyOnContext()) {
-                        pluginInstance.onInit();
                         pluginInstance.onEnable();
                         this.handlePluginActions(pluginInstance.getActions());
                     }


### PR DESCRIPTION
Currently, the onInit function is in the handleLoading function.
The handleLoading function is called one time and call the onInit function if is valid in the scope and in the context.