### PR TITLE
[Bundle] #115 The first category of bundle in the drop list should be visible

### DIFF
--- a/src/tb/apps/bundle/templates/list.twig
+++ b/src/tb/apps/bundle/templates/list.twig
@@ -1,6 +1,6 @@
 <div id="extensions" class="bb5-dialog ui-dialog-no-title">
     {% for name, category in categories %}
-    <div class="bb5-data-toggle">
+    <div class="bb5-data-toggle {% if loop.first %}open{% endif %}">
         <div class="bb5-data-toggle-header">
             {{ name }}
             <span class="bb5-data-toggle-trigger">


### PR DESCRIPTION
In order to help the user find a bundle, show him how bundles are organized (accordeons)