### PR TITLE
[Bundle] #114 Add a popin to confirm the activation/desactivation of a bundle

### DIFF
--- a/src/tb/apps/bundle/controllers/main.controller.js
+++ b/src/tb/apps/bundle/controllers/main.controller.js
@@ -47,7 +47,7 @@ define(['tb.core', 'bundle.view.list', 'bundle.view.index'], function (Core, Lis
                 config.force = true;
                 config.bindEvents = true;
 
-                this.renderView(IndexView, {});
+                this.renderView(IndexView, config);
             }
 
             this.listAndRender(IndexView, config);

--- a/src/tb/apps/bundle/views/bundle.view.index.js
+++ b/src/tb/apps/bundle/views/bundle.view.index.js
@@ -60,7 +60,7 @@ define(
                 }
 
                 this.force = (config.force === true);
-                this.doBinding = (config.doBinding === true);
+                this.doBinding = (config.bindEvents === true);
             },
 
             /**
@@ -90,15 +90,22 @@ define(
              */
             doExtensionActivation: function (event) {
                 var self = jQuery(event.currentTarget),
-                    bundleId = self.parent().attr('data-bundle-id');
-
-                self.siblings('a').removeClass('active');
-                self.addClass('active');
+                    bundleId = self.parent().attr('data-bundle-id'),
+                    enableClass,
+                    enable;
 
                 if (self.hasClass('enable')) {
-                    BundleRepository.active(true, bundleId);
+                    enableClass = "enable";
+                    enable = true;
                 } else if (self.hasClass('disable')) {
-                    BundleRepository.active(false, bundleId);
+                    enableClass = "disable";
+                    enable = false;
+                }
+
+                if (confirm('Do you want to ' + enableClass + ' this bundle ?')) {
+                    self.siblings('a').removeClass('active');
+                    self.addClass('active');
+                    BundleRepository.active(enable, bundleId);
                 }
             },
 


### PR DESCRIPTION
Better add a popin to confirm the activation/desactivation of a bundle

Activating desactivating a bundle can be a key issue, in case of missclick it is important to have this security.