### PR TITLE
Forcing get pagination response to be an array

### DIFF
--- a/specs/tb/core/Utils.spec.js
+++ b/specs/tb/core/Utils.spec.js
@@ -5,6 +5,24 @@ define(['require', 'tb.core', "tb.core.Utils"], function (require) {
         bbUtils = require("tb.core.Utils");
     describe("Utils spec", function () {
         /* setup */
+        it("Test castAsArray", function () {
+            var obj = {
+                    'test': 'value',
+                    2: 'value',
+                    '3': 'value3'
+                },
+
+                arr = [
+                    'value',
+                    'value'
+                ],
+
+                objInArr = bbUtils.castAsArray(obj);
+
+            expect(objInArr instanceof Array).toBe(true);
+            expect(objInArr.length).toBe(3);
+            expect(bbUtils.castAsArray(arr)).toBe(arr);
+        });
         it("Creates a SmartList", function () {
             smartList = new core.SmartList();
             expect(smartList).toBeDefined();

--- a/src/tb/apps/user/controllers/group.controller.js
+++ b/src/tb/apps/user/controllers/group.controller.js
@@ -18,8 +18,8 @@
  */
 
 define(
-    ['tb.core', 'tb.core.Renderer', 'component!notify'],
-    function (Core, renderer, Notify) {
+    ['tb.core', 'tb.core.Renderer', 'component!notify', 'tb.core.Utils'],
+    function (Core, renderer, Notify, Utils) {
         'use strict';
 
         Core.ControllerManager.registerController('GroupController', {
@@ -56,6 +56,8 @@ define(
                 this.repository.paginate().then(
                     function (groups) {
                         var i;
+                        groups = Utils.castAsArray(groups);
+
                         for (i = 0; i < groups.length; i = i + 1) {
                             groups[i] = new View({group: groups[i]});
                         }

--- a/src/tb/apps/user/controllers/user.controller.js
+++ b/src/tb/apps/user/controllers/user.controller.js
@@ -18,8 +18,8 @@
  */
 
 define(
-    ['tb.core', 'tb.core.Renderer', 'user/entity/user', 'component!notify', 'require'],
-    function (Core, renderer, User, Notify, require) {
+    ['tb.core', 'tb.core.Renderer', 'user/entity/user', 'component!notify', 'require', 'tb.core.Utils'],
+    function (Core, renderer, User, Notify, require, Utils) {
         'use strict';
 
         Core.ControllerManager.registerController('UserController', {
@@ -52,6 +52,8 @@ define(
                     function (users) {
                         var i,
                             user;
+
+                        users = Utils.castAsArray(users);
 
                         for (i = users.length - 1; i >= 0; i = i - 1) {
                             user = new User();

--- a/src/tb/core/Utils.js
+++ b/src/tb/core/Utils.js
@@ -281,10 +281,23 @@ define('tb.core.Utils', ['jquery', 'tb.core.Api'], function (jQuery, Api) {
                 });
             }
             return def.promise();
+        },
+
+        castAsArray = function (values) {
+            if (values instanceof Object && !(values instanceof Array)) {
+                values = Object.keys(values).map(
+                    function (key) {
+                        return values[key];
+                    }
+                );
+            }
+            return values;
         };
+
     Api.register('SmartList', SmartList);
     return {
         SmartList: SmartList,
-        requireWithPromise: requireWithPromise
+        requireWithPromise: requireWithPromise,
+        castAsArray: castAsArray
     };
 });


### PR DESCRIPTION
I create this PR, because currently I have a problem with the response type in getCollectionAction from the User Rest Controller. This evol permit to avoid bad typing response from the server and help the JS to continuing working correctly.

I add a new function into Utils class castAsArray to transform an object into an array.
And I use that function into group and user controller to avoid the badly response type from the BackBee REST server.