### PR TITLE
[mediator] improvement of the mediator exceptions

### DIFF
--- a/specs/tb/core/Mediator.spec.js
+++ b/specs/tb/core/Mediator.spec.js
@@ -21,7 +21,17 @@ define(['require', 'tb.core'], function (require) {
             spyOn(api.exception, 'silent');
 
             api.Mediator.publish('a fake event', argument);
-            expect(api.exception.silent).toHaveBeenCalledWith('MediatorException', 12201, 'Mediator as catch an error on "' + 'a fake event' + '" topic with the following message: "' + 'Fake error' + '"');
+            expect(api.exception.silent).toHaveBeenCalledWith(
+                'MediatorException',
+                12201,
+                'Mediator caught an error when the topic : "' + 'a fake event' + '" was published.',
+                {
+                    topic: 'a fake event',
+                    context: undefined,
+                    callback: fake.withoutThis,
+                    args: ['not realy']
+                }
+            );
 
             api.Mediator.unsubscribe('a fake event', fake.withoutThis);
         });
@@ -38,6 +48,14 @@ define(['require', 'tb.core'], function (require) {
 
             api.Mediator.publish('another fake event', argument);
             expect(console.info).not.toHaveBeenCalled();
+        });
+
+        it('Subscribe with no context them publish', function () {
+            api.Mediator.subscribe('another fake event', fake.withThis);
+            spyOn(fake, 'withoutThis');
+
+            api.Mediator.publish('another fake event', argument);
+            expect(fake.withoutThis).not.toHaveBeenCalledWith(argument);
         });
 
         it('Persistent publish an post subscribe', function () {

--- a/src/tb/core/Mediator.js
+++ b/src/tb/core/Mediator.js
@@ -111,7 +111,17 @@ define('tb.core.Mediator', ['tb.core.Api'], function (Api) {
                 try {
                     this.topics[topic][i].execute.apply(this.topics[topic][i], args);
                 } catch (e) {
-                    Api.exception.silent('MediatorException', 12201, 'Mediator as catch an error on "' + topic + '" topic with the following message: "' + e + '"');
+                    Api.exception.silent(
+                        'MediatorException',
+                        12201,
+                        'Mediator caught an error when the topic : "' + topic + '" was published.',
+                        {
+                            topic: topic,
+                            context: this.topics[topic][i].context,
+                            callback: this.topics[topic][i].callback,
+                            args: args
+                        }
+                    );
                 }
                 if (this.subscribe_once.hasOwnProperty(topic)) {
                     for (i = 0; i < this.subscribe_once[topic].length; i = i + 1) {


### PR DESCRIPTION
I have rewrite the mediator exception to ease debugging.
 * The message is more short
 * Add params exception where you can find now : topic, context, callback and arguments

I have update the exception test.

[bonus] I add one more test for a case was not already tested (Subscribe with no context them publish) that check the fact of the context is undefined by default.