### PR TITLE
Add services autobinding on scopes

### DIFF
--- a/src/tb/core/Scope.js
+++ b/src/tb/core/Scope.js
@@ -27,7 +27,9 @@ define('tb.core.Scope', ['tb.core.Api', 'underscore'], function (Api, Under) {
 
     var Scope = function scope() {
             this.scopes = [];
-            Api.Mediator.persistentPublish('scope:global:opening');
+            Api.Mediator.subscribeOnce('on:application:ready', function () {
+                Api.Mediator.persistentPublish('scope:global:opening');
+            });
         },
 
         /**

--- a/src/tb/main.js
+++ b/src/tb/main.js
@@ -21,9 +21,10 @@
     require.config({
         paths: {
             'tb.core.Api': 'src/tb/core/Api',
+            'tb.core.Mediator': 'src/tb/core/Mediator',
+            'tb.core.Scope': 'src/tb/core/Scope',
             'tb.core.ApplicationManager': 'src/tb/core/ApplicationManager',
             'tb.core.ApplicationContainer': 'src/tb/core/ApplicationContainer',
-            'tb.core.Mediator': 'src/tb/core/Mediator',
             'tb.core.RouteManager': 'src/tb/core/RouteManager',
             'tb.core.Renderer': 'src/tb/core/Renderer',
             'tb.core.ControllerManager': 'src/tb/core/ControllerManager',
@@ -34,7 +35,6 @@
             'tb.core.RequestHandler': 'src/tb/core/RequestHandler',
             'tb.core.Response': 'src/tb/core/Response',
             'tb.core.RestDriver': 'src/tb/core/RestDriver',
-            'tb.core.Scope': 'src/tb/core/Scope',
             'tb.core.Config': 'src/tb/core/Config'
         }
     });


### PR DESCRIPTION
This update, allow applications to expose service outer the main app in a scope.

config example
```yaml
user:
    scope:
        global:
            open: controllername.servicename
            close: controllername.otherservicename
```

parameters open and close are optional.

I took the opportunity to clean a little ApplicationManager by removing console.log and renaming the variable with the standards name.
