### PR TITLE
removing create draft page

### DIFF
--- a/src/tb/apps/page/templates/contribution.index.twig
+++ b/src/tb/apps/page/templates/contribution.index.twig
@@ -23,11 +23,6 @@
     </div>
     <div class="col-bb5-24 bb5-border-right">
         <p>
-            <button type="button" class="btn btn-simple btn-xs btn-block">
-                <i class="fa fa-pencil-square-o"></i> {{ 'create_a_draft'|trans }}
-            </button>
-        </p>
-        <p>
             <button id="contribution-clone-page" type="button" class="btn btn-simple btn-xs btn-block">
                 <i class="fa fa-file-o"></i> {{ 'duplicate'|trans }}
             </button>


### PR DESCRIPTION
Just button deletion in the page template because the functionality is not created in core php. #399 