### PR TITLE
Add placeholder content has no property name

### DIFF
--- a/src/tb/apps/content/widgets/Breadcrumb.js
+++ b/src/tb/apps/content/widgets/Breadcrumb.js
@@ -65,7 +65,7 @@ define(
 
             computeElement: function (content) {
                 return {
-                    'name': content.getDefinition('properties').name,
+                    'name': content.getDefinition('properties').name || content.type,
                     'id': content.id
                 };
             },


### PR DESCRIPTION
Just a little placeholder in case the property name is not available (case met was with content set)