### PR TITLE
Fixed redirection on page duplication

### DIFF
--- a/src/tb/apps/page/controllers/main.controller.js
+++ b/src/tb/apps/page/controllers/main.controller.js
@@ -127,6 +127,8 @@ define(
             },
 
             clonePageService: function (config) {
+
+                config.callbackAfterSubmit = this.newPageRedirect;
                 var view = new CloneView(config);
                 view.render();
             },


### PR DESCRIPTION
This enforces the redirection to the newly duplicated page. (refs: https://github.com/backbee/backbee-standard/issues/113)