### PR TITLE
Fixed #556 - Change bad credentials label

### DIFF
--- a/src/tb/component/session/session.js
+++ b/src/tb/component/session/session.js
@@ -85,7 +85,7 @@ define('tb.component/session/session', ['Core', 'Core/Utils', 'jsclass'], functi
                 Utils.requireWithPromise(['component!authentication']).then(
                     function (authenticate) {
                         authenticate.popin.unmask();
-                        authenticate.showForm('Bad credentials');
+                        authenticate.showForm('login or password incorrect');
                     }
                 );
             }


### PR DESCRIPTION
See #556 , changed "Bad credentials" to "login or password incorrect".

Notice: we don't have any access to the translator component atm.