### PR TITLE
Fixed #615 - redirection after page deletion on page tree plugin

### DIFF
--- a/src/tb/apps/page/views/page.view.tree.contribution.js
+++ b/src/tb/apps/page/views/page.view.tree.contribution.js
@@ -202,7 +202,8 @@ define(
                                         },
                                         serviceConfig = {
                                             'uid': self.currentEvent.node.id,
-                                            'callbackAfterSubmit': callback
+                                            'callbackAfterSubmit': callback,
+                                            'doRedirect': true
                                         };
 
                                     ApplicationManager.invokeService('page.main.deletePage', serviceConfig);


### PR DESCRIPTION
On page tree view, the "Remove" option didn't redirect the user.

So, a deleted page seems to be already there, until you reload by yourself (and catch a Not found), now the behavior is the good one.

