### PR TITLE
REFS #605 - cancel/validate/draft popins are now center top displayed

### DIFF
--- a/src/tb/apps/page/views/page.view.contribution.index.js
+++ b/src/tb/apps/page/views/page.view.contribution.index.js
@@ -272,9 +272,11 @@ define(
              * Get the metadata of page, build form and show in popin
              */
             manageSeo: function () {
+
                 var self = this,
+                    popinTopPosition = jQuery('#' + Core.get('menu.id')).height(),
                     popin = PopinManager.createPopIn({
-                        position: { my: "center top", at: "center top+" + jQuery('#' + Core.get('menu.id')).height()}
+                        position: { my: "center top", at: "center top+" + popinTopPosition}
                     });
 
                 popin.setTitle(translator.translate('page_seo'));

--- a/src/tb/component/revisionselector/main.js
+++ b/src/tb/component/revisionselector/main.js
@@ -92,7 +92,9 @@ define(
                 buildPopin: function () {
                     var title = (this.config.popinTitle !== undefined) ? this.config.popinTitle : '';
 
-                    this.popin = PopinManager.createPopIn();
+                    this.popin = PopinManager.createPopIn({
+                        position: { my: "center top", at: "center top+" + jQuery('#' + Core.get('menu.id')).height()}
+                    });
                     this.popin.setTitle(title);
                     this.popin.addOptions(popinConfig);
                 },


### PR DESCRIPTION
![popin-top-displayed](https://cloud.githubusercontent.com/assets/1247388/7730449/b83c7202-ff1a-11e4-916e-f0bd18c097f8.png)


https://github.com/backbee/BbCoreJs/issues/605