### PR TITLE
Fix reconnect after session expired

### DIFF
--- a/src/tb/init.js
+++ b/src/tb/init.js
@@ -43,15 +43,19 @@ define(function () {
                             event.ctrlKey &&
                             event.altKey
                     ) {
-                        this.load();
+                        this.load(true);
                     }
                 }
             },
 
-            load: function () {
+            load: function (removeSession) {
                 var self = this;
                 require(['vendor'], function () {
                     require(['Core', 'component!session', 'jquery'], function (Core, session, jQuery) {
+
+                        if (removeSession === true) {
+                            session.destroy();
+                        }
 
                         Core.set('session', session);
                         Core.set('is_connected', session.isAuthenticated());


### PR DESCRIPTION
If the PHP session is expired, the js session is always in local storage.