### PR TITLE
[Component] [Contentselector] Remove non exist require content.grid.view.tpl

### DIFF
--- a/src/tb/component/contentselector/helper/content.renderer.js
+++ b/src/tb/component/contentselector/helper/content.renderer.js
@@ -31,7 +31,6 @@ define(
         'Core',
         'text!cs-templates/content.list.edit.view.tpl',
         'text!cs-templates/content.delete.tpl',
-        'text!cs-templates/content.grid.view.tpl',
         'text!cs-templates/content.list.view.tpl'
     ],
     function (require) {


### PR DESCRIPTION
A contentselector can't be open cause that require a bad file.