### PR TITLE
Fixed DefinitionManager::addDefinition to use right syntax of document element style property

### DIFF
--- a/src/tb/apps/content/components/DefinitionManager.js
+++ b/src/tb/apps/content/components/DefinitionManager.js
@@ -34,10 +34,7 @@ define(['jsclass'], function () {
             if (null === this.find(definition.type)) {
                 img = document.createElement('img');
                 img.src = definition.image;
-                img.style = {
-                    width: '25px',
-                    height: '25px'
-                };
+                img.style.cssText = 'width: 25px, height: 25px';
                 definition.img = img;
 
                 this.definitions.push(definition);


### PR DESCRIPTION
Last update of Google Chrome ``43.0.2357.65 m`` does not allow anymore this syntax:

```js
img = document.createElement('img');
img.style = {
    width: '25px',
    height: '25px'
};
```

Instead of this use this:

```js
img = document.createElement('img');
img.style.cssText = 'width: 25px, height: 25px';
```

Btw this is the right expected syntax.