### PR TITLE
Specific error message between session timeout and bad authentication…

### DIFF
--- a/src/tb/component/session/session.js
+++ b/src/tb/component/session/session.js
@@ -78,12 +78,13 @@ define('tb.component/session/session', ['Core', 'Core/Utils', 'jsclass'], functi
                 );
 
             } else if (response.getStatus() === 401) {
+
                 this.destroy();
                 Core.set('is_connected', false);
                 Utils.requireWithPromise(['component!authentication']).then(
                     function (authenticate) {
                         authenticate.popin.unmask();
-                        authenticate.showForm('login or password incorrect');
+                        authenticate.showForm(response.errorText);
                     }
                 );
             }


### PR DESCRIPTION
… informations

REFS #538 

Two captures:

![bad_login](https://cloud.githubusercontent.com/assets/1247388/7773393/81756054-00a4-11e5-929c-1a65603e4d2c.png)
![session_timeout](https://cloud.githubusercontent.com/assets/1247388/7773397/83338fd8-00a4-11e5-9751-893647e36c7e.png)

Error messages are from PHP core /c @clementbonfils do you **realy** need other custom messages ?