### PR TITLE
The cookie is now available from subpages

### DIFF
--- a/src/tb/apps/user/controllers/user.controller.js
+++ b/src/tb/apps/user/controllers/user.controller.js
@@ -317,7 +317,7 @@ define(
                 DriverHandler.delete('security/session').then(
                     function () {
                         req('component!session').destroy();
-                        document.cookie = 'PHPSESSID=; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+                        document.cookie = 'PHPSESSID=; expires=Thu, 01 Jan 1970 00:00:01 GMT;path=/';
                         document.location.reload();
                     }
                 );


### PR DESCRIPTION
This fix issue backbee/backbee-standard#298 (the logout on subpages doesn't work as expected).

The fix allow subpages to update cookie form domains.

ping @ndufreche 