### PR TITLE
REFS #359 - Remove "_top" and "_parent" option to new page creation

### DIFF
--- a/src/tb/apps/page/forms/AbstractPage.form.js
+++ b/src/tb/apps/page/forms/AbstractPage.form.js
@@ -43,9 +43,7 @@ define(
                     label: 'Target',
                     options: {
                         '_self': '_self',
-                        '_blank': '_blank',
-                        '_parent': '_parent',
-                        '_top': '_top'
+                        '_blank': '_blank'
                     }
                 },
                 url: {


### PR DESCRIPTION
this fix this issue => https://github.com/backbee/backbee-standard/issues/359