### PR TITLE
use parseInt because string is received

### DIFF
--- a/src/tb/apps/page/components/SaveManager.js
+++ b/src/tb/apps/page/components/SaveManager.js
@@ -41,7 +41,7 @@ define(
                     'key': 'state_code',
                     'label': 'State',
                     'treatment': function (value) {
-                        return (value === 0) ? 'Offline' : 'Online';
+                        return (parseInt(value, 10) === 0) ? 'Offline' : 'Online';
                     }
                 },
                 'publishing': {


### PR DESCRIPTION
Note this patch don't fix the translation issue on Online/Offline.