### PR TITLE
Fix preload on content edit if empty elements

### DIFF
--- a/src/tb/apps/content/widgets/Edition.js
+++ b/src/tb/apps/content/widgets/Edition.js
@@ -137,19 +137,23 @@ define(
                     }
                 }
 
-                require('content.repository').findByUids(uids).done(function (elements) {
-                    var element,
-                        key2;
+                if (uids.length > 0) {
+                    require('content.repository').findByUids(uids).done(function (elements) {
+                        var element,
+                            key2;
 
-                    for (key2 in elements) {
-                        if (elements.hasOwnProperty(key2)) {
-                            element = elements[key2];
-                            ContentManager.buildElement({'type': element.type, 'uid': element.uid, 'elementData': element});
+                        for (key2 in elements) {
+                            if (elements.hasOwnProperty(key2)) {
+                                element = elements[key2];
+                                ContentManager.buildElement({'type': element.type, 'uid': element.uid, 'elementData': element});
+                            }
                         }
-                    }
 
+                        dfd.resolve();
+                    });
+                } else {
                     dfd.resolve();
-                });
+                }
 
                 return dfd.promise();
             },


### PR DESCRIPTION
If the content don't have elements a call for fetch all content are called