### PR TITLE
add test for undefined var

### DIFF
--- a/src/tb/apps/content/components/ContentManager.js
+++ b/src/tb/apps/content/components/ContentManager.js
@@ -296,7 +296,7 @@ define(
                     refreshPicture = function (img) {
                         var src = img.attr('src');
 
-                        if (src.length === 0 || img.naturalWidth === 0) {
+                        if (src === undefined || src.length === 0 || img.naturalWidth === 0) {
                             src = require('content.manager').defaultPicturePath;
 
                         }


### PR DESCRIPTION
I add a test for src var in contentmanager.js

if src is undefined, contentmanager put defaultPicturePath instead throw an error.