### PR TITLE
Pushing the commits limit sent at the same time to 30

### DIFF
--- a/src/tb/apps/content/repository/revision.repository.js
+++ b/src/tb/apps/content/repository/revision.repository.js
@@ -35,7 +35,7 @@ define(
 
             TYPE: 'classcontent-draft',
 
-            limit: 3,
+            limit: 30,
 
             /**
              * Initialize of Page repository


### PR DESCRIPTION
After some tests, the user is waiting far more time the validation of his drafts when API calls are highly split.
On my not so powerful pc, 23 contents validated 3 by 3 reach the php timeout limit for half of the 8 calls.
Pushing the limit to 30 (so only one API call) it's ok!

I propose to set the limit to 30 and to plan a perf. study on several limit value.