### PR TITLE
Fix JSON.parse on empty string

### DIFF
--- a/src/tb/component/formsubmitter/elements/contentTypeSelector.js
+++ b/src/tb/component/formsubmitter/elements/contentTypeSelector.js
@@ -31,7 +31,11 @@ define(['jsclass'], function () {
                 previousValue = form.elements[key].value;
 
             if (value !== JSON.stringify(previousValue)) {
-                data = JSON.parse(value);
+                if (value) {
+                    data = JSON.parse(value);
+                } else {
+                    data = {};
+                }
             }
             return data;
         }


### PR DESCRIPTION
Currently an error is thrown when value is empty