### PR TITLE
Removed external link selector regex validation

### DIFF
--- a/src/tb/component/linkselector/main.js
+++ b/src/tb/component/linkselector/main.js
@@ -175,9 +175,8 @@ define(
                                 self.close(data);
                             },
                             onValidate: function (form, data) {
-                                var urlPattern = new RegExp(/^(https?:\/\/){1}([\da-z\.\-]+)\.([a-z\.]{2,6})([\/\w \.\-]*)*\/?$/);
 
-                                if (!data.hasOwnProperty('url') || jQuery.trim(data.url).length === 0 || !urlPattern.test(data.url)) {
+                                if (!data.hasOwnProperty('url') || jQuery.trim(data.url).length === 0) {
                                     form.addError('url', Translator.translate('url_required'));
                                 }
                             }


### PR DESCRIPTION
In order to be able to contribute various type of url in external links selector (http(s), mailto, with get parameters ? or anchor #, etc...), removed the validation regex and test (Charles suggestion).