### PR TITLE
Tree adjustments refs:#5362

### DIFF
--- a/src/tb/apps/contribution/views/contribution.view.index.js
+++ b/src/tb/apps/contribution/views/contribution.view.index.js
@@ -31,17 +31,18 @@ define(
             bindEvents: function () {
                 var element = jQuery('#' + this.id);
 
+                this.loadPopinTree();
                 element.on('click', 'ul#edit-tab li', this.manageMenu);
                 element.on('click', '#new-page', this.showNewPage);
                 element.on('click', '.global-save', this.manageSave);
-                element.on('click', '#bundle-toolbar-tree', this.showTree);
+                element.on('click', '#bundle-toolbar-tree', this.showPopinTree);
                 element.on('click', '#bundle-toolbar-contentSelector', this.showContentSelector);
                 element.on('click', '.bundle-toolbar-global-validate', this.manageValidate);
                 element.on('click', '.bundle-toolbar-global-cancel', this.manageCancel);
                 element.on("click", "#btn-show-mediaLibrary", this.showMediaLibrary);
                 element.on("click", "#keyword-editor", this.showKwEditor.bind(this));
                 if (sessionStorage.getItem('loadTree') === 'true') {
-                    this.showTree();
+                    this.showPopinTree();
                 }
             },
 
@@ -60,8 +61,7 @@ define(
                 }
             },
 
-            showTree: function () {
-                sessionStorage.setItem('loadTree', 'true');
+            loadPopinTree: function () {
                 var popinId = 'bb-page-tree',
                     treePromise,
                     config = {
@@ -72,18 +72,23 @@ define(
                         popinId: popinId,
                         autoLoadRoot: true
                     };
-                if (document.getElementById(popinId) !== null) {
-                    jQuery('#' + popinId).dialog('open');
-                } else {
-                    treePromise = Core.ApplicationManager.invokeService('page.main.tree', config);
-                    treePromise.done(function (pageTreeContribution) {
-                        pageTreeContribution.view.on("rootIsLoaded", function () {
-                            pageTreeContribution.view.showFilter();
-                            pageTreeContribution.selectPage(Core.get("page.uid"));
-                        });
-
+                treePromise = Core.ApplicationManager.invokeService('page.main.tree', config);
+                treePromise.done(function (pageTreeContribution) {
+                    pageTreeContribution.view.on("rootIsLoaded", function () {
+                        pageTreeContribution.view.showFilter();
+                        pageTreeContribution.selectPage(Core.get("page.uid"));
                     });
+
+                });
+            },
+            showPopinTree: function () {
+                var popinId = 'bb-page-tree',
+                    popinHolder = jQuery('#' + popinId).parent();
+                sessionStorage.setItem('loadTree', 'true');
+                if (jQuery(popinHolder).css('display') === 'none') {
+                    jQuery(popinHolder).show();
                 }
+                jQuery('#' + popinId).dialog('open');
             },
 
             showNewPage: function () {

--- a/src/tb/apps/page/views/page.view.tree.contribution.js
+++ b/src/tb/apps/page/views/page.view.tree.contribution.js
@@ -217,16 +217,15 @@ define(
                                     var callback = function (data, response) {
                                         RequestHandler.send(self.buildRequest(response.getHeader('Location'))).done(function (page) {
                                             if (self.currentEvent.node.before_load === false) {
-                                                self.treeView.invoke('appendNode', self.view.formatePageToNode(page), self.currentEvent.node);
+                                                self.treeView.invoke('addNodeAfter', self.view.formatePageToNode(page), self.currentEvent.node);
                                             }
                                         });
 
                                         return data;
                                     }, serviceConfig = {
-                                        'parent_uid': self.currentEvent.node.id,
+                                        'parent_uid': ((self.currentEvent.node.parent.id !== undefined) ? self.currentEvent.node.parent.id : self.currentEvent.node.id),
                                         'callbackAfterSubmit': callback
                                     };
-
                                     ApplicationManager.invokeService('page.main.newPage', serviceConfig);
                                 }
                             },

--- a/src/tb/apps/page/views/page.view.tree.js
+++ b/src/tb/apps/page/views/page.view.tree.js
@@ -176,6 +176,9 @@ define(
 
                 if (this.config.popin === true) {
                     this.tree = Tree.createPopinTreeView(config);
+                    if (sessionStorage.getItem('loadTree') === null) {
+                        jQuery('#' + this.tree.popIn.id).parent().hide();
+                    }
                     this.treeView = this.tree.treeView;
                     this.tree.on("click", ".show_folder_action", this.handleSectionFilter, this);
                     Core.ApplicationManager.invokeService('content.main.registerPopin', 'treeView', this.tree);


### PR DESCRIPTION
Changes for the following requests:
2. Pages that have subpages must be displayed before single pages
3. When creating a new page, display the page right after it parent . when reloading tree, page must go down after pages that have children
4. As soon as the toobar is loaded , load the tree in background task (for user to have it display quick when he'll click on it)(edited)