### PR TITLE
#683 fix block display cant be opened twice

### DIFF
--- a/src/tb/apps/content/views/content.view.contribution.index.js
+++ b/src/tb/apps/content/views/content.view.contribution.index.js
@@ -71,7 +71,7 @@ define(
             },
 
             onPaletteBlocksClick: function () {
-                if (this.widget === undefined) {
+                if (this.widget === undefined || this.widget.popin.state === 2) {
                     this.widget = new DialogContentsList({'draggable': true});
                 }
                 this.widget.show();


### PR DESCRIPTION
Fix for https://github.com/backbee/backbee-standard/issues/683
After destroy the popin couldn't open anymore.