### PR TITLE
fix default render mode for ClassContent

### DIFF
--- a/src/tb/apps/content/models/AbstractContent.js
+++ b/src/tb/apps/content/models/AbstractContent.js
@@ -443,7 +443,7 @@ define(
             },
 
             getRendermode: function () {
-                var rendermode = 'default';
+                var rendermode = '';
 
                 if (undefined !== this.jQueryObject) {
                     if (this.jQueryObject.data('rendermode')) {


### PR DESCRIPTION
The "default" render mode was "hard forced" in code.
This prevented the selection of a proper default render mode in a ClassContent yml configuration.
This fix is linked to ToolbarBundle #102 (https://github.com/backbee/ToolbarBundle/pull/102).
Please merge both at the same time.

Thanks