### PR TITLE
fix bundle admin template full width

### DIFF
--- a/src/tb/apps/bundle/templates/admin.twig
+++ b/src/tb/apps/bundle/templates/admin.twig
@@ -1,5 +1,5 @@
 <div id="bundle-admin-popin" class="container">
     <div class="row">
-        <div class="col-md-12">{{ content }}</div>
+        <div class="col-bb5-100">{{ content }}</div>
     </div>
 </div>


### PR DESCRIPTION
The bundle admin layout was not full-width. The column width is now 100%.
Thanks.